### PR TITLE
Fix Bundesagentur oversized query coverage

### DIFF
--- a/src/ats_scrapers/scrapers/bundesagentur.py
+++ b/src/ats_scrapers/scrapers/bundesagentur.py
@@ -447,11 +447,7 @@ class BundesagenturScraper(BaseScraper):
                     ):
                         return items_by_reference
 
-        raise ScraperError(
-            "Bundesagentur verified cover is incomplete: "
-            f"collected {len(items_by_reference)} unique jobs for "
-            f"total={total}, params={base_params}"
-        )
+        return items_by_reference
 
     async def _fan_out_pages(
         self,

--- a/src/ats_scrapers/scrapers/bundesagentur.py
+++ b/src/ats_scrapers/scrapers/bundesagentur.py
@@ -16,26 +16,18 @@ details remain on the v4 endpoint.
 The API caps pagination at ``size × page = 10,000`` results per query
 (``size=100, page=100``). Past that limit, the server returns 400.
 
-To collect the full ~1M jobs we subdivide *recursively* by orthogonal
-facets in priority order: ``berufsfeld`` (144 categories) →
-``arbeitszeit`` (5 work-time buckets, e.g. ``vz``/``tz``) →
-``zeitarbeit`` (2 — temp work yes/no) → ``befristung`` (3 — permanent /
-fixed-term / vocational). At each level we only descend if the bucket
-still exceeds the 10k cap. Empirically this is enough to break every
-oversize category into <10k leaves.
+To collect the full ~1M jobs we subdivide *recursively* using only facets
+whose bucket counts form an exact, non-overlapping partition of the current
+query. If the API exposes no such partition for an oversized leaf, we build
+an overlapping cover from every official sort order plus high-cardinality
+facets, deduplicate by reference number, and accept it only when its unique
+row count reaches the API's advertised total. Otherwise the scrape fails
+closed and preserves the previous complete dataset.
 
 The earlier version subdivided by Bundesland names, but the API's
 ``arbeitsort`` filter expects *city* names (e.g. ``"Berlin"``,
 ``"München"``), not states (``"Bayern"`` returns 0) — that bug capped
 output at ~301k.
-
-A subsequent 4-facet version (``berufsfeld → arbeitszeit → zeitarbeit →
-befristung``) still capped near ~301-500k because the tail facets are
-heavily skewed (~84% in the dominant bucket each), so the worst leaf —
-Verkauf + vz + false + befristung=3 — still held 56k jobs against a
-10k cap. The current 6-facet recursion adds ``eintrittsdatum`` (24
-month windows) and ``arbeitgeber`` (top-100 employers per leaf), which
-is enough to drive every dominant leaf below 10k.
 
 Single-tenant scraper: ``company_slug`` is informational and ignored.
 The output rows carry the German employer name as ``company`` so the
@@ -66,7 +58,7 @@ API_KEY = "jobboerse-jobsuche"  # Public key shared by the official frontend.
 PAGE_SIZE = 100
 PAGE_LIMIT = 100  # size × page caps at 10,000 → max page=100 at size=100.
 PAGINATION_CAP = PAGE_SIZE * PAGE_LIMIT
-# The 6-facet recursion issues 10k+ requests for a full scrape. The
+# The recursive fan-out issues 10k+ requests for a full scrape. The
 # arbeitsagentur API has an Akamai-style WAF that returns 403 under
 # burst load. A shared global semaphore at 2 + sequential page fan-out
 # within each leaf keeps the request pace below the WAF threshold while
@@ -99,6 +91,19 @@ _SUBDIVISION_FACETS = (
     "arbeitgeber",
 )
 MAX_SUBDIVISION_DEPTH = len(_SUBDIVISION_FACETS)
+
+# The official frontend exposes these four sort orders. Different orderings
+# surface different records before the API's hard 10k pagination cap.
+_COVER_SORTS = (
+    "relevanz",
+    "veroeffdatum",
+    "moddatum",
+    "eintrittsdatum",
+)
+# These API-provided facets are intentionally allowed to overlap or omit a
+# small tail. They are not trusted as partitions; they are only used to add
+# records to a locally deduplicated cover whose final size is verified.
+_COVER_FACETS = ("beruf", "arbeitsort")
 
 
 class _PageFetchExhaustedError(ScraperError):
@@ -278,9 +283,9 @@ class BundesagenturScraper(BaseScraper):
     ) -> None:
         """Recursively pull all jobs matching ``base_params``.
 
-        Pagination caps at 10k. If the query exceeds that, pick the next
-        unused subdivision facet and split. ``depth`` bounds the
-        recursion: berufsfeld → arbeitszeit → zeitarbeit → befristung.
+        Pagination caps at 10k. If the query exceeds that, use an exact
+        facet partition when available, then fall back to a verified
+        overlapping cover. ``depth`` bounds recursive facet subdivision.
         """
         first = await self._fetch_page(
             client, sem, params={**base_params, "size": 1, "page": 1},
@@ -301,10 +306,15 @@ class BundesagenturScraper(BaseScraper):
         applied = set(base_params.keys())
         partition = _select_partition(first, total=total, applied=applied)
         if partition is None or depth >= MAX_SUBDIVISION_DEPTH:
-            raise ScraperError(
-                f"Bundesagentur cannot losslessly partition {total} jobs "
-                f"for params={base_params}"
+            await self._collect_verified_cover(
+                client,
+                sem,
+                base_params=base_params,
+                total=total,
+                initial_payload=first,
+                absorb=absorb,
             )
+            return
         facet_name, bucket_counts = partition
 
         async def child_bucket(value: str, count: int) -> None:
@@ -319,6 +329,82 @@ class BundesagenturScraper(BaseScraper):
         await asyncio.gather(
             *(child_bucket(v, c) for v, c in bucket_counts.items())
         )
+
+    async def _collect_verified_cover(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        base_params: dict[str, Any],
+        total: int,
+        initial_payload: dict[str, Any],
+        absorb: Callable[[list[dict[str, Any]]], Awaitable[None]],
+    ) -> None:
+        """Recover an oversized leaf without treating overlaps as partitions.
+
+        The API exposes several official sort orders and high-cardinality
+        facets, each of which reveals a different slice before the 10k cap.
+        Collect their union locally, deduplicate by reference number, and only
+        release rows to the caller after a fresh total probe confirms coverage.
+        """
+        items_by_reference: dict[str, dict[str, Any]] = {}
+
+        async def collect_pages(params: dict[str, Any], count: int) -> None:
+            page_count = min(
+                (count + PAGE_SIZE - 1) // PAGE_SIZE,
+                PAGE_LIMIT,
+            )
+            for page in range(1, page_count + 1):
+                payload = await self._fetch_page(
+                    client,
+                    sem,
+                    params={**params, "size": PAGE_SIZE, "page": page},
+                )
+                for item in _result_items(payload):
+                    reference = _item_reference(item)
+                    if reference:
+                        items_by_reference[reference] = item
+
+        covered = False
+        for sort in _COVER_SORTS:
+            await collect_pages({**base_params, "sort": sort}, total)
+            if len(items_by_reference) >= total:
+                covered = True
+                break
+
+        facets = initial_payload.get("facetten")
+        if not covered and isinstance(facets, dict):
+            for facet_name in _COVER_FACETS:
+                counts = _bucket_counts(facets, facet_name)
+                for value, count in sorted(
+                    counts.items(), key=lambda item: item[1], reverse=True
+                ):
+                    if count > PAGINATION_CAP:
+                        continue
+                    await collect_pages(
+                        {**base_params, facet_name: value},
+                        count,
+                    )
+                    if len(items_by_reference) >= total:
+                        covered = True
+                        break
+                if covered:
+                    break
+
+        latest = await self._fetch_page(
+            client,
+            sem,
+            params={**base_params, "size": 1, "page": 1},
+        )
+        latest_total = int(latest.get("maxErgebnisse") or 0)
+        if len(items_by_reference) < latest_total:
+            raise ScraperError(
+                "Bundesagentur verified cover is incomplete: "
+                f"collected {len(items_by_reference)} unique jobs for "
+                f"latest_total={latest_total}, initial_total={total}, "
+                f"params={base_params}"
+            )
+        await absorb(list(items_by_reference.values()))
 
     async def _fan_out_pages(
         self,
@@ -416,7 +502,7 @@ class BundesagenturScraper(BaseScraper):
         )
 
     def _parse(self, item: dict[str, Any]) -> Job | None:
-        ats_id = str(item.get("referenznummer") or item.get("refnr") or "").strip()
+        ats_id = _item_reference(item)
         title = str(
             item.get("stellenangebotsTitel")
             or item.get("titel")
@@ -574,6 +660,10 @@ def _result_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
     if not all(isinstance(item, dict) for item in items):
         raise ScraperError("Bundesagentur v6 returned a non-object job")
     return items
+
+
+def _item_reference(item: dict[str, Any]) -> str:
+    return str(item.get("referenznummer") or item.get("refnr") or "").strip()
 
 
 def _employment_details(

--- a/src/ats_scrapers/scrapers/bundesagentur.py
+++ b/src/ats_scrapers/scrapers/bundesagentur.py
@@ -104,6 +104,9 @@ _COVER_SORTS = (
 # small tail. They are not trusted as partitions; they are only used to add
 # records to a locally deduplicated cover whose final size is verified.
 _COVER_FACETS = ("beruf", "arbeitsort")
+MAX_COVER_TOTAL = 25_000
+MAX_COVER_ATTEMPTS = 3
+COVER_ABSORB_BATCH_SIZE = 500
 
 
 class _PageFetchExhaustedError(ScraperError):
@@ -290,7 +293,7 @@ class BundesagenturScraper(BaseScraper):
         first = await self._fetch_page(
             client, sem, params={**base_params, "size": 1, "page": 1},
         )
-        total = int(first.get("maxErgebnisse") or 0)
+        total = _result_total(first)
         if total == 0:
             return
         # Page-1 hits are already paid for — absorb them rather than re-fetch.
@@ -311,7 +314,6 @@ class BundesagenturScraper(BaseScraper):
                 sem,
                 base_params=base_params,
                 total=total,
-                initial_payload=first,
                 absorb=absorb,
             )
             return
@@ -337,7 +339,6 @@ class BundesagenturScraper(BaseScraper):
         *,
         base_params: dict[str, Any],
         total: int,
-        initial_payload: dict[str, Any],
         absorb: Callable[[list[dict[str, Any]]], Awaitable[None]],
     ) -> None:
         """Recover an oversized leaf without treating overlaps as partitions.
@@ -345,11 +346,66 @@ class BundesagenturScraper(BaseScraper):
         The API exposes several official sort orders and high-cardinality
         facets, each of which reveals a different slice before the 10k cap.
         Collect their union locally, deduplicate by reference number, and only
-        release rows to the caller after a fresh total probe confirms coverage.
+        release rows after two consecutive passes return the same exact set.
         """
+        if total > MAX_COVER_TOTAL:
+            raise ScraperError(
+                f"Bundesagentur refuses an unbounded cover of {total} jobs "
+                f"for params={base_params}"
+            )
+
+        previous_references: set[str] | None = None
+        for _attempt in range(MAX_COVER_ATTEMPTS):
+            start = await self._fetch_page(
+                client,
+                sem,
+                params={**base_params, "size": 1, "page": 1},
+            )
+            start_total = _result_total(start)
+            if start_total > MAX_COVER_TOTAL:
+                raise ScraperError(
+                    f"Bundesagentur refuses an unbounded cover of "
+                    f"{start_total} jobs for params={base_params}"
+                )
+            items_by_reference = await self._build_cover_pass(
+                client,
+                sem,
+                base_params=base_params,
+                total=start_total,
+                initial_payload=start,
+            )
+            end = await self._fetch_page(
+                client,
+                sem,
+                params={**base_params, "size": 1, "page": 1},
+            )
+            end_total = _result_total(end)
+            references = set(items_by_reference)
+            stable_count = len(references) == start_total == end_total
+            if stable_count and references == previous_references:
+                items = list(items_by_reference.values())
+                for offset in range(0, len(items), COVER_ABSORB_BATCH_SIZE):
+                    await absorb(items[offset:offset + COVER_ABSORB_BATCH_SIZE])
+                return
+            previous_references = references if stable_count else None
+
+        raise ScraperError(
+            "Bundesagentur could not obtain two stable verified covers for "
+            f"params={base_params} after {MAX_COVER_ATTEMPTS} attempts"
+        )
+
+    async def _build_cover_pass(
+        self,
+        client: httpx.AsyncClient,
+        sem: asyncio.Semaphore,
+        *,
+        base_params: dict[str, Any],
+        total: int,
+        initial_payload: dict[str, Any],
+    ) -> dict[str, dict[str, Any]]:
         items_by_reference: dict[str, dict[str, Any]] = {}
 
-        async def collect_pages(params: dict[str, Any], count: int) -> None:
+        async def collect_pages(params: dict[str, Any], count: int) -> bool:
             page_count = min(
                 (count + PAGE_SIZE - 1) // PAGE_SIZE,
                 PAGE_LIMIT,
@@ -364,16 +420,16 @@ class BundesagenturScraper(BaseScraper):
                     reference = _item_reference(item)
                     if reference:
                         items_by_reference[reference] = item
+                if len(items_by_reference) >= total:
+                    return True
+            return False
 
-        covered = False
         for sort in _COVER_SORTS:
-            await collect_pages({**base_params, "sort": sort}, total)
-            if len(items_by_reference) >= total:
-                covered = True
-                break
+            if await collect_pages({**base_params, "sort": sort}, total):
+                return items_by_reference
 
         facets = initial_payload.get("facetten")
-        if not covered and isinstance(facets, dict):
+        if isinstance(facets, dict):
             for facet_name in _COVER_FACETS:
                 counts = _bucket_counts(facets, facet_name)
                 for value, count in sorted(
@@ -381,30 +437,17 @@ class BundesagenturScraper(BaseScraper):
                 ):
                     if count > PAGINATION_CAP:
                         continue
-                    await collect_pages(
+                    if await collect_pages(
                         {**base_params, facet_name: value},
                         count,
-                    )
-                    if len(items_by_reference) >= total:
-                        covered = True
-                        break
-                if covered:
-                    break
+                    ):
+                        return items_by_reference
 
-        latest = await self._fetch_page(
-            client,
-            sem,
-            params={**base_params, "size": 1, "page": 1},
+        raise ScraperError(
+            "Bundesagentur verified cover is incomplete: "
+            f"collected {len(items_by_reference)} unique jobs for "
+            f"total={total}, params={base_params}"
         )
-        latest_total = int(latest.get("maxErgebnisse") or 0)
-        if len(items_by_reference) < latest_total:
-            raise ScraperError(
-                "Bundesagentur verified cover is incomplete: "
-                f"collected {len(items_by_reference)} unique jobs for "
-                f"latest_total={latest_total}, initial_total={total}, "
-                f"params={base_params}"
-            )
-        await absorb(list(items_by_reference.values()))
 
     async def _fan_out_pages(
         self,
@@ -660,6 +703,21 @@ def _result_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
     if not all(isinstance(item, dict) for item in items):
         raise ScraperError("Bundesagentur v6 returned a non-object job")
     return items
+
+
+def _result_total(payload: dict[str, Any]) -> int:
+    value = payload.get("maxErgebnisse")
+    if isinstance(value, bool):
+        raise ScraperError("Bundesagentur response has invalid maxErgebnisse")
+    try:
+        total = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ScraperError(
+            "Bundesagentur response is missing a valid maxErgebnisse"
+        ) from exc
+    if total < 0:
+        raise ScraperError("Bundesagentur response has negative maxErgebnisse")
+    return total
 
 
 def _item_reference(item: dict[str, Any]) -> str:

--- a/src/ats_scrapers/scrapers/bundesagentur.py
+++ b/src/ats_scrapers/scrapers/bundesagentur.py
@@ -81,6 +81,8 @@ _SUBDIVISION_FACETS = (
     "angebotsart",
     "ausbildungsart",
     "berufsfeld",
+    "beruf",
+    "schulbildung",
     "befristung",
     "zeitarbeit",
     "pav",
@@ -431,6 +433,8 @@ class BundesagenturScraper(BaseScraper):
         facets = initial_payload.get("facetten")
         if isinstance(facets, dict):
             for facet_name in _COVER_FACETS:
+                if facet_name in base_params:
+                    continue
                 counts = _bucket_counts(facets, facet_name)
                 for value, count in sorted(
                     counts.items(), key=lambda item: item[1], reverse=True

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -123,19 +123,65 @@ def test_partition_ignores_non_exhaustive_facets() -> None:
     )
 
 
-def test_oversize_query_without_lossless_partition_crashes(httpx_mock) -> None:
+def test_oversize_query_without_verified_cover_crashes(
+    httpx_mock, monkeypatch
+) -> None:
+    import ats_scrapers.scrapers.bundesagentur as ba
+
+    monkeypatch.setattr(ba, "PAGE_SIZE", 1)
+    monkeypatch.setattr(ba, "PAGE_LIMIT", 1)
+    monkeypatch.setattr(ba, "PAGINATION_CAP", 1)
     httpx_mock.add_response(
         url=_API_RE,
         json={
             "ergebnisliste": [_job("1", "Probe")],
-            "maxErgebnisse": 10_001,
-            "facetten": {"berufsfeld": {"counts": {"IT": 9_000}}},
+            "maxErgebnisse": 2,
+            "facetten": {},
         },
         is_reusable=True,
     )
 
-    with pytest.raises(ScraperError, match="cannot losslessly partition"):
+    with pytest.raises(ScraperError, match="verified cover is incomplete"):
         BundesagenturScraper("any").fetch()
+
+
+def test_oversize_query_uses_verified_overlapping_cover(
+    httpx_mock, monkeypatch
+) -> None:
+    import ats_scrapers.scrapers.bundesagentur as ba
+
+    monkeypatch.setattr(ba, "PAGE_SIZE", 2)
+    monkeypatch.setattr(ba, "PAGE_LIMIT", 1)
+    monkeypatch.setattr(ba, "PAGINATION_CAP", 2)
+
+    def serve(request: httpx.Request) -> httpx.Response:
+        params = parse_qs(urlparse(str(request.url)).query)
+        size = int(params.get("size", ["1"])[0])
+        profession = params.get("beruf", [None])[0]
+        if size == 1:
+            items = [_job("A", "Job A")]
+        elif profession == "missing-tail":
+            items = [_job("C", "Job C")]
+        else:
+            items = [_job("A", "Job A"), _job("B", "Job B")]
+        return httpx.Response(
+            200,
+            json={
+                "ergebnisliste": items,
+                "maxErgebnisse": 3,
+                "facetten": {
+                    "beruf": {
+                        "counts": {"common": 2, "missing-tail": 1}
+                    }
+                },
+            },
+        )
+
+    httpx_mock.add_callback(serve, url=_API_RE, is_reusable=True)
+
+    jobs = BundesagenturScraper("any").fetch()
+
+    assert {job.ats_id for job in jobs} == {"A", "B", "C"}
 
 
 # --- Retry exhaustion: abort rather than publish a partial catalogue --------

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -123,6 +123,30 @@ def test_partition_ignores_non_exhaustive_facets() -> None:
     )
 
 
+def test_partition_uses_exact_profession_buckets() -> None:
+    from ats_scrapers.scrapers.bundesagentur import _select_partition
+
+    payload = {
+        "facetten": {
+            "beruf": {
+                "counts": {
+                    "Kaufmann/-frau - Einzelhandel": 8_000,
+                    "Verkäufer/in": 4_000,
+                }
+            },
+            "arbeitszeit": {"counts": {"vz": 11_900, "tz": 300}},
+        }
+    }
+
+    assert _select_partition(payload, total=12_000, applied=set()) == (
+        "beruf",
+        {
+            "Kaufmann/-frau - Einzelhandel": 8_000,
+            "Verkäufer/in": 4_000,
+        },
+    )
+
+
 def test_oversize_query_without_verified_cover_crashes(
     httpx_mock, monkeypatch
 ) -> None:
@@ -157,10 +181,10 @@ def test_oversize_query_uses_verified_overlapping_cover(
     def serve(request: httpx.Request) -> httpx.Response:
         params = parse_qs(urlparse(str(request.url)).query)
         size = int(params.get("size", ["1"])[0])
-        profession = params.get("beruf", [None])[0]
+        location = params.get("arbeitsort", [None])[0]
         if size == 1:
             items = [_job("A", "Job A")]
-        elif profession == "missing-tail":
+        elif location == "missing-tail":
             items = [_job("C", "Job C")]
         else:
             items = [_job("A", "Job A"), _job("B", "Job B")]
@@ -170,7 +194,7 @@ def test_oversize_query_uses_verified_overlapping_cover(
                 "ergebnisliste": items,
                 "maxErgebnisse": 3,
                 "facetten": {
-                    "beruf": {
+                    "arbeitsort": {
                         "counts": {"common": 2, "missing-tail": 1}
                     }
                 },
@@ -197,7 +221,7 @@ def test_verified_cover_retries_catalogue_churn(httpx_mock, monkeypatch) -> None
         params = parse_qs(urlparse(str(request.url)).query)
         size = int(params.get("size", ["1"])[0])
         sort = params.get("sort", [None])[0]
-        profession = params.get("beruf", [None])[0]
+        location = params.get("arbeitsort", [None])[0]
         if size == 1:
             items = [_job("B", "Job B")]
         else:
@@ -206,13 +230,13 @@ def test_verified_cover_retries_catalogue_churn(httpx_mock, monkeypatch) -> None
             if pass_number == 1:
                 items = (
                     [_job("C", "Job C")]
-                    if profession == "missing-tail"
+                    if location == "missing-tail"
                     else [_job("A", "Job A"), _job("B", "Job B")]
                 )
             else:
                 items = (
                     [_job("D", "Job D")]
-                    if profession == "missing-tail"
+                    if location == "missing-tail"
                     else [_job("B", "Job B"), _job("C", "Job C")]
                 )
         return httpx.Response(
@@ -221,7 +245,7 @@ def test_verified_cover_retries_catalogue_churn(httpx_mock, monkeypatch) -> None
                 "ergebnisliste": items,
                 "maxErgebnisse": 3,
                 "facetten": {
-                    "beruf": {
+                    "arbeitsort": {
                         "counts": {"common": 2, "missing-tail": 1}
                     }
                 },

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -165,7 +165,7 @@ def test_oversize_query_without_verified_cover_crashes(
         is_reusable=True,
     )
 
-    with pytest.raises(ScraperError, match="verified cover is incomplete"):
+    with pytest.raises(ScraperError, match="two stable verified covers"):
         BundesagenturScraper("any").fetch()
 
 
@@ -258,6 +258,42 @@ def test_verified_cover_retries_catalogue_churn(httpx_mock, monkeypatch) -> None
 
     assert {job.ats_id for job in jobs} == {"B", "C", "D"}
     assert pass_number == 3
+
+
+def test_verified_cover_retries_catalogue_shrink(httpx_mock, monkeypatch) -> None:
+    import ats_scrapers.scrapers.bundesagentur as ba
+
+    monkeypatch.setattr(ba, "PAGE_SIZE", 2)
+    monkeypatch.setattr(ba, "PAGE_LIMIT", 1)
+    monkeypatch.setattr(ba, "PAGINATION_CAP", 2)
+    probe_number = 0
+
+    def serve(request: httpx.Request) -> httpx.Response:
+        nonlocal probe_number
+        params = parse_qs(urlparse(str(request.url)).query)
+        size = int(params.get("size", ["1"])[0])
+        if size == 1:
+            probe_number += 1
+            total = 3 if probe_number <= 2 else 2
+            items = [_job("A", "Job A")]
+        else:
+            total = 2
+            items = [_job("A", "Job A"), _job("B", "Job B")]
+        return httpx.Response(
+            200,
+            json={
+                "ergebnisliste": items,
+                "maxErgebnisse": total,
+                "facetten": {},
+            },
+        )
+
+    httpx_mock.add_callback(serve, url=_API_RE, is_reusable=True)
+
+    jobs = BundesagenturScraper("any").fetch()
+
+    assert {job.ats_id for job in jobs} == {"A", "B"}
+    assert probe_number == 7
 
 
 def test_missing_result_total_is_a_contract_break(httpx_mock) -> None:

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -184,6 +184,69 @@ def test_oversize_query_uses_verified_overlapping_cover(
     assert {job.ats_id for job in jobs} == {"A", "B", "C"}
 
 
+def test_verified_cover_retries_catalogue_churn(httpx_mock, monkeypatch) -> None:
+    import ats_scrapers.scrapers.bundesagentur as ba
+
+    monkeypatch.setattr(ba, "PAGE_SIZE", 2)
+    monkeypatch.setattr(ba, "PAGE_LIMIT", 1)
+    monkeypatch.setattr(ba, "PAGINATION_CAP", 2)
+    pass_number = 0
+
+    def serve(request: httpx.Request) -> httpx.Response:
+        nonlocal pass_number
+        params = parse_qs(urlparse(str(request.url)).query)
+        size = int(params.get("size", ["1"])[0])
+        sort = params.get("sort", [None])[0]
+        profession = params.get("beruf", [None])[0]
+        if size == 1:
+            items = [_job("B", "Job B")]
+        else:
+            if sort == "relevanz":
+                pass_number += 1
+            if pass_number == 1:
+                items = (
+                    [_job("C", "Job C")]
+                    if profession == "missing-tail"
+                    else [_job("A", "Job A"), _job("B", "Job B")]
+                )
+            else:
+                items = (
+                    [_job("D", "Job D")]
+                    if profession == "missing-tail"
+                    else [_job("B", "Job B"), _job("C", "Job C")]
+                )
+        return httpx.Response(
+            200,
+            json={
+                "ergebnisliste": items,
+                "maxErgebnisse": 3,
+                "facetten": {
+                    "beruf": {
+                        "counts": {"common": 2, "missing-tail": 1}
+                    }
+                },
+            },
+        )
+
+    httpx_mock.add_callback(serve, url=_API_RE, is_reusable=True)
+
+    jobs = BundesagenturScraper("any").fetch()
+
+    assert {job.ats_id for job in jobs} == {"B", "C", "D"}
+    assert pass_number == 3
+
+
+def test_missing_result_total_is_a_contract_break(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        json={"ergebnisliste": [_job("1", "Probe")]},
+        is_reusable=True,
+    )
+
+    with pytest.raises(ScraperError, match="valid maxErgebnisse"):
+        BundesagenturScraper("any").fetch()
+
+
 # --- Retry exhaustion: abort rather than publish a partial catalogue --------
 
 


### PR DESCRIPTION
## Summary
- recover oversized v6 leaves with an overlapping cover from official sort orders and API facets
- deduplicate by Bundesagentur reference and verify against a fresh advertised total
- remain fail-closed when the cover is incomplete

## Validation
- `pytest tests/test_bundesagentur.py -q` (15 passed)
- `ruff check .`
- full local suite: 1862 passed, 2 skipped; 5 unrelated Moka failures because the existing local venv lacks `pycryptodome`
- live blocked-leaf probe: 11,957/11,957 unique jobs recovered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Bundesagentur oversized query coverage so the scraper no longer crashes when a query exceeds the 10k pagination cap and no exact facet partition exists.

- Partitions by additional exact facets (`beruf`, `schulbildung`) before falling back to an overlapping cover from official sort orders and high-cardinality facets.
- Deduplicates by Bundesagentur reference number and accepts the cover only when two consecutive passes return the same unique set, failing closed otherwise.
- Treats missing or invalid `maxErgebnisse` as a contract break and adds tests covering the verified-cover path, catalogue churn and shrink retries, and the incomplete-cover crash.

<sup>Written for commit 78fa7cb089d383a733ba463d27e52e2ad0acbc66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a fallback for oversized Bundesagentur searches by collecting results from multiple official sort orders and facet buckets before checking the latest advertised total. A mocked end-to-end scraper run showed that, when the remote catalogue changes membership without changing its total, the scraper can publish a removed job and omit a newly active job.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until fallback collection is tied to a stable result snapshot or fails when membership cannot be verified.

A deterministic mocked HTTP execution through the public scraper path reproduced the stale-result failure with a same-count catalogue change.

**Files Needing Attention:** src/ats_scrapers/scrapers/bundesagentur.py needs a membership-aware verification strategy for oversized-result fallback collection.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and attached three validation artifacts showing the stale-cover validation source and the baseline and changed-membership outputs.
- T-Rex produced a second proof for another posted P1 finding.
- T-Rex ran the stale-cover validation script and compared baseline and changed-membership outputs, confirming the baseline published state is A,B,C while the changed-membership indicates final probe B,C,D with latest\_total=3, and that the scraper still returns published A,B,C with exit code 0.

<a href="https://app.greptile.com/trex/runs/21481968/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Verified cover accepts stale references when membership changes at the same total**

   - **Bug**
     - `_collect_verified_cover` collects and deduplicates references from an earlier API snapshot. After the final total probe reports the same count but a changed membership, `len(items_by_reference) < latest_total` is false and `absorb` publishes the old union. In the executed reproduction, stale `A` was published and active `D` was omitted.
   - **Cause**
     - The final verification uses only aggregate cardinality (`len(items_by_reference)`) and never revalidates collected references against the latest snapshot or a stable API snapshot/version.
   - **Fix**
     - Treat a changed catalogue during cover collection as unverifiable and fail closed, or obtain a snapshot/version token and require it across all cover requests and final validation. A mere latest count must not authorize absorbing earlier references.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ats_scrapers/scrapers/bundesagentur.py:400-407
**Snapshot verification accepts stale references**

The final probe verifies only that the number of previously collected references is at least the current `maxErgebnisse`; it does not verify that those references still belong to the current result set. If the catalogue changes while the capped sort and facet requests run but keeps the same total, the scraper can pass this check and publish jobs that were removed while omitting newly active jobs. The mocked fetch execution collected `A,B,C`, received a final active snapshot of `B,C,D` with the same total of three, and still completed successfully while publishing stale `A` instead of `D`. Fail closed when the result set cannot be tied to one stable snapshot, or use an API snapshot/version token consistently across collection and verification.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Bundesagentur oversized query covera..."](https://github.com/kalil0321/ats-scrapers/commit/88ea7cb7649687963aff6c4ce19ac039bc7c7a65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58387034)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->