### PR TITLE
Cover Bundesagentur additional professions

### DIFF
--- a/src/ats_scrapers/scrapers/bundesagentur.py
+++ b/src/ats_scrapers/scrapers/bundesagentur.py
@@ -105,7 +105,7 @@ _COVER_SORTS = (
 # These API-provided facets are intentionally allowed to overlap or omit a
 # small tail. They are not trusted as partitions; they are only used to add
 # records to a locally deduplicated cover whose final size is verified.
-_COVER_FACETS = ("beruf", "arbeitsort")
+_COVER_FACETS = ("beruf", "arbeitsort", "weitereberufe")
 MAX_COVER_TOTAL = 25_000
 MAX_COVER_ATTEMPTS = 3
 COVER_ABSORB_BATCH_SIZE = 500

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -181,10 +181,10 @@ def test_oversize_query_uses_verified_overlapping_cover(
     def serve(request: httpx.Request) -> httpx.Response:
         params = parse_qs(urlparse(str(request.url)).query)
         size = int(params.get("size", ["1"])[0])
-        location = params.get("arbeitsort", [None])[0]
+        additional_profession = params.get("weitereberufe", [None])[0]
         if size == 1:
             items = [_job("A", "Job A")]
-        elif location == "missing-tail":
+        elif additional_profession == "missing-tail":
             items = [_job("C", "Job C")]
         else:
             items = [_job("A", "Job A"), _job("B", "Job B")]
@@ -196,7 +196,10 @@ def test_oversize_query_uses_verified_overlapping_cover(
                 "facetten": {
                     "arbeitsort": {
                         "counts": {"common": 2, "missing-tail": 1}
-                    }
+                    },
+                    "weitereberufe": {
+                        "counts": {"common": 2, "missing-tail": 1}
+                    },
                 },
             },
         )


### PR DESCRIPTION
## What
- add the official `weitereberufe` facet to oversized-leaf coverage
- extend the regression test past `arbeitsort` into the new facet

## Live evidence
For the blocked Maschinenbau leaf, existing sorts + `beruf` + `arbeitsort` consistently recovered 13,186 of 13,187 jobs. `weitereberufe` added the one missing reference and reached 13,187/13,187.

## Validation
- `uv run pytest -q tests/test_bundesagentur.py` (19 passed)
- `uv run ruff check src/ats_scrapers/scrapers/bundesagentur.py tests/test_bundesagentur.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `weitereberufe` facet to the Bundesagentur oversized-leaf cover so jobs tagged under additional professions are no longer missed. Previously `beruf` and `arbeitsort` only recovered 13,186 of 13,187 jobs for the blocked Maschinenbau leaf; adding this facet recovers the last one.

- Updates the regression test to verify the new facet recovers the missing tail.

<sup>Written for commit 46653e07f4dcdf040272ce4271be0ef77779dc0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds the official `weitereberufe` facet to Bundesagentur’s oversized-query recovery cover and updates the regression scenario accordingly. A mocked API exercise confirmed that a listing unavailable through sort orders, profession, and location buckets is recovered through the additional-profession bucket, while deduplication and repeated count-complete verification remain intact. No defects were identified.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised oversized-query recovery path.

The focused before-and-after check demonstrated that the prior facet set cannot recover the tail listing, while this change retrieves it and completes the existing verification safeguards. The repository regression for the same behavior also passed.

**Files Needing Attention:** No follow-up changes are needed in `src/ats_scrapers/scrapers/bundesagentur.py` or `tests/test_bundesagentur.py`.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused mocked-HTTP regression against the parent revision and the current revision; the parent failed its count-complete cover requirement while the current revision passed with three distinct jobs after querying the additional-profession bucket.
- Executed the PR276 cover facet e2e regression and observed 1 passed in 0.38s.
- Ran the targeted Bundesagentur regression test and observed 1 passed in 0.19s.
- Performed an exact-before/after regression check around the bundesagentur scraper; the pre-change run produced a ScraperError about start/unique/end, and the post-change run passed as expected.

<a href="https://app.greptile.com/trex/runs/21506800/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Cover Bundesagentur additional professio..."](https://github.com/kalil0321/ats-scrapers/commit/46653e07f4dcdf040272ce4271be0ef77779dc0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58433105)</sub>

<!-- /greptile_comment -->