### PR TITLE
Retry incomplete Bundesagentur responses

### DIFF
--- a/src/ats_scrapers/scrapers/bundesagentur.py
+++ b/src/ats_scrapers/scrapers/bundesagentur.py
@@ -510,14 +510,31 @@ class BundesagenturScraper(BaseScraper):
                 try:
                     payload = r.json()
                 except ValueError as exc:
-                    raise ScraperError(
-                        f"Bundesagentur returned non-JSON for {params}: {exc}"
-                    ) from exc
-                if not isinstance(payload, dict):
-                    raise ScraperError(
-                        f"Bundesagentur returned a non-object payload for {params}"
-                    )
-                return payload
+                    last_exc = exc
+                else:
+                    if not isinstance(payload, dict):
+                        last_exc = ScraperError(
+                            "Bundesagentur returned a non-object payload"
+                        )
+                    else:
+                        try:
+                            _result_items(payload)
+                            _result_total(payload)
+                        except ScraperError as exc:
+                            last_exc = exc
+                        else:
+                            return payload
+                if attempt == MAX_RETRIES:
+                    raise _PageFetchExhaustedError(
+                        "Bundesagentur returned an invalid 200 payload for "
+                        f"{params} after {MAX_RETRIES} retries: {last_exc}"
+                    ) from last_exc
+                base = RETRY_BASE_DELAY * (2 ** attempt)
+                delay = base * (
+                    1 + random.uniform(-RETRY_JITTER, RETRY_JITTER)
+                )
+                await asyncio.sleep(delay)
+                continue
             if r.status_code == 400:
                 raise ScraperError(
                     f"Bundesagentur rejected query {params}: {r.text[:120]}"

--- a/src/ats_scrapers/scrapers/bundesagentur.py
+++ b/src/ats_scrapers/scrapers/bundesagentur.py
@@ -525,7 +525,7 @@ class BundesagenturScraper(BaseScraper):
                         else:
                             return payload
                 if attempt == MAX_RETRIES:
-                    raise _PageFetchExhaustedError(
+                    raise ScraperError(
                         "Bundesagentur returned an invalid 200 payload for "
                         f"{params} after {MAX_RETRIES} retries: {last_exc}"
                     ) from last_exc

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -395,8 +395,9 @@ def test_malformed_json_crashes_not_skips(httpx_mock) -> None:
         content=b"<html>Maintenance</html>",
         is_reusable=True,
     )
-    with pytest.raises(ScraperError):
+    with pytest.raises(ScraperError) as exc_info:
         BundesagenturScraper("any").fetch()
+    assert type(exc_info.value) is ScraperError
 
 
 def test_incomplete_200_retries_then_succeeds(httpx_mock) -> None:

--- a/tests/test_bundesagentur.py
+++ b/tests/test_bundesagentur.py
@@ -387,9 +387,7 @@ def test_root_probe_404_crashes_not_skips(httpx_mock) -> None:
 
 
 def test_malformed_json_crashes_not_skips(httpx_mock) -> None:
-    """A 200 OK with a malformed body is a contract break — the schema
-    we're parsing against is unknown — and must crash rather than
-    soft-fail to ``[]``."""
+    """Repeated malformed 200 responses must fail closed."""
     from ats_scrapers.exceptions import ScraperError
     httpx_mock.add_response(
         url=_API_RE,
@@ -399,6 +397,24 @@ def test_malformed_json_crashes_not_skips(httpx_mock) -> None:
     )
     with pytest.raises(ScraperError):
         BundesagenturScraper("any").fetch()
+
+
+def test_incomplete_200_retries_then_succeeds(httpx_mock) -> None:
+    httpx_mock.add_response(
+        url=_API_RE,
+        status_code=200,
+        json={"maxErgebnisse": 1},
+    )
+    httpx_mock.add_response(
+        url=_API_RE,
+        status_code=200,
+        json={"ergebnisliste": [_job("1", "Probe")], "maxErgebnisse": 1},
+        is_reusable=True,
+    )
+
+    jobs = BundesagenturScraper("any").fetch()
+
+    assert {job.ats_id for job in jobs} == {"1"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
- validate required v6 list fields inside the retried page fetch
- retry malformed, non-object, or schema-incomplete HTTP 200 payloads
- still fail closed after the existing retry budget

## Production evidence
The hotfix run reached 595,984 streamed jobs, then received an HTTP 200 payload without `ergebnisliste`. The old path failed immediately and preserved the prior output; this change treats that transient upstream body like the already-retried WAF/server failures.

## Validation
- `uv run pytest -q tests/test_bundesagentur.py` (20 passed)
- `uv run ruff check src/ats_scrapers/scrapers/bundesagentur.py tests/test_bundesagentur.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries Bundesagentur HTTP 200 responses that are non-JSON, non-object, or missing required list fields, so a transient incomplete payload no longer fails the whole run. Previously these responses raised immediately; now they use the existing retry backoff and the run still fails closed only after the retry budget is exhausted.

<sup>Written for commit 11cefe387c1aeb9adbcfc13db3398fd248bd3ffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kalil0321/ats-scrapers/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes the Bundesagentur scraper retry malformed or structurally incomplete HTTP 200 search responses before accepting page data. The public fetch flow was exercised with mocked responses: an incomplete response recovered on a later valid response, persistent invalid responses failed closed after the retry limit, and valid responses still returned jobs. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on deterministic coverage of the changed response-validation and retry behavior.

The public scraper path passed recovery, persistent-invalid-response, and valid-response scenarios with mocked HTTP transport, and no author action is required.

**Files Needing Attention:** No files need follow-up attention; the exercised implementation is in src/ats_scrapers/scrapers/bundesagentur.py and its focused coverage is in tests/test_bundesagentur.py.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the Bundesagentur page fetch validation script against the public BundesagenturScraper.fetch() path using the given environment.
- Observed exit code 0 and a sequence where one job was retrieved, six invalid HTTP 200 responses were raised as \_PageFetchExhaustedError, and a subsequent valid HTTP 200 response returned one job.
- Concluded that the updated retry handling recovers from temporarily invalid payloads and fails closed when invalid payloads persist.

<a href="https://app.greptile.com/trex/runs/21513773/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Retry incomplete Bundesagentur responses"](https://github.com/kalil0321/ats-scrapers/commit/256f55162bf9860f56eb8e44130bcd01c82fb846) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58450716)</sub>

<!-- /greptile_comment -->