### PR TITLE
fix: retry ByteDance catalogue churn

### DIFF
--- a/src/ats_scrapers/scrapers/bytedance.py
+++ b/src/ats_scrapers/scrapers/bytedance.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
 API_URL = "https://jobs.bytedance.com/api/v1/public/supplier/search/job/posts"
 PAGE_SIZE = 100
 MAX_RETRIES = 4
+MAX_CATALOGUE_ATTEMPTS = 2
 
 HEADERS = {
     "accept": "*/*",
@@ -59,6 +60,10 @@ HEADERS = {
 }
 
 
+class _CatalogueChangedError(ScraperError):
+    """The upstream catalogue changed while offset pagination was in progress."""
+
+
 @ScraperRegistry.register(ATSType.BYTEDANCE)
 class BytedanceScraper(BaseScraper):
     """ByteDance scraper — `company_slug` is informational; jobs are global."""
@@ -67,6 +72,15 @@ class BytedanceScraper(BaseScraper):
     default_headers: ClassVar[dict[str, str]] = HEADERS
 
     async def afetch(self) -> list[Job]:
+        for attempt in range(1, MAX_CATALOGUE_ATTEMPTS + 1):
+            try:
+                return await self._fetch_catalogue()
+            except _CatalogueChangedError:
+                if attempt == MAX_CATALOGUE_ATTEMPTS:
+                    raise
+        raise AssertionError("unreachable")
+
+    async def _fetch_catalogue(self) -> list[Job]:
         all_jobs: list[Job] = []
         seen_ids: set[str] = set()
         reported_total: int | None = None
@@ -101,7 +115,7 @@ class BytedanceScraper(BaseScraper):
                 if reported_total is None:
                     reported_total = total
                 elif total != reported_total:
-                    raise ScraperError(
+                    raise _CatalogueChangedError(
                         "ByteDance response changed count during pagination "
                         f"({reported_total} to {total})"
                     )
@@ -144,7 +158,7 @@ class BytedanceScraper(BaseScraper):
                         f"was reached ({offset}/{total})"
                     )
         if reported_total is None or len(seen_ids) != reported_total:
-            raise ScraperError(
+            raise _CatalogueChangedError(
                 "ByteDance catalogue ended before the reported count "
                 f"({len(seen_ids)}/{reported_total} unique jobs)"
             )

--- a/tests/test_bytedance.py
+++ b/tests/test_bytedance.py
@@ -311,8 +311,11 @@ def test_fetch_rejects_short_page_before_reported_count(httpx_mock) -> None:
 
 
 def test_fetch_rejects_overlapping_pages_before_reported_count(
-    httpx_mock,
+    httpx_mock, monkeypatch
 ) -> None:
+    monkeypatch.setattr(
+        "ats_scrapers.scrapers.bytedance.MAX_CATALOGUE_ATTEMPTS", 1
+    )
     first_page = [
         {**_FIXTURE, "id": str(index)}
         for index in range(PAGE_SIZE)
@@ -342,6 +345,35 @@ def test_fetch_rejects_overlapping_pages_before_reported_count(
         match=rf"{PAGE_SIZE + PAGE_SIZE // 2}/{total} unique jobs",
     ):
         BytedanceScraper("any").fetch()
+
+
+def test_fetch_retries_catalogue_after_overlapping_pages(httpx_mock) -> None:
+    first_page = [
+        {**_FIXTURE, "id": str(index)}
+        for index in range(PAGE_SIZE)
+    ]
+    overlapping_page = [
+        {**_FIXTURE, "id": str(index)}
+        for index in range(PAGE_SIZE // 2, PAGE_SIZE + PAGE_SIZE // 2)
+    ]
+    second_page = [
+        {**_FIXTURE, "id": str(index)}
+        for index in range(PAGE_SIZE, PAGE_SIZE * 2)
+    ]
+    total = PAGE_SIZE * 2
+    for jobs in (first_page, overlapping_page, first_page, second_page):
+        httpx_mock.add_response(
+            url=API_URL,
+            json={
+                "code": 0,
+                "data": {"job_post_list": jobs, "count": total},
+            },
+        )
+
+    result = BytedanceScraper("any").fetch()
+
+    assert len(result) == total
+    assert len({job.ats_id for job in result}) == total
 
 
 # --- Helper-function units --------------------------------------------------


### PR DESCRIPTION
## Problem

The exact-head release live run exposed a catalogue-churn race in the ByteDance offset pagination: the API reported 1,363 rows, but page movement produced 1,359 unique IDs, so the scraper correctly failed closed.

Failure: https://github.com/kalil0321/ats-scrapers/actions/runs/33675882711

A direct full-catalogue probe immediately afterward returned 1,363 rows and 1,363 unique IDs, confirming a transient mutation during pagination rather than a stable parse failure.

## Fix

- retry the entire catalogue once when the reported count changes or overlapping pages leave fewer unique IDs than reported
- keep request-level retries separate
- remain fail-closed if the second full snapshot is also inconsistent
- add a regression test that reproduces overlapping pages and verifies a clean second snapshot

## Validation

- `uv run ruff check .`
- `uv run mypy src/ats_scrapers/scrapers/bytedance.py`
- `uv run pytest tests/test_bytedance.py -q` — 38 passed
- focused real endpoint test — 1 passed, 1,363 jobs fetched
- [full live E2E on the exact PR head](https://github.com/kalil0321/ats-scrapers/actions/runs/33676796834) — 35 passed
- `uv run pytest -q` — 1,873 passed, 2 skipped, 35 deselected


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds one bounded full-catalogue retry when ByteDance pagination observes a changing count or an incomplete unique-ID set. Executable mocked pagination checks verified that recovery restarts at offset zero, returns only jobs from the clean second snapshot, and still rejects persistent catalogue churn without returning partial results. The focused ByteDance test suite passed with 38 tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised ByteDance pagination recovery and persistent-failure paths.

The targeted execution covered count changes, overlapping IDs, retry offset reset, replacement-snapshot isolation, and persistent churn; the focused regression suite also passed.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the ByteDance catalogue churn validation workflow against the base revision and ran the churn validation script and tests to establish the baseline.
- Compared the baseline behavior and confirmed the parent revision stopped after two page requests for each churn condition.
- Validated PR head behavior by running the same validation and observed four paginator calls with offsets 0, 100, 0, 100, with recoverable churn returning 200 IDs from the second-\* snapshot.
- Confirmed that persistent overlap raises \_CatalogueChangedError after the fourth request and that no partial catalogue is returned.

<a href="https://app.greptile.com/trex/runs/22136663/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Retry ByteDance catalogue churn"](https://github.com/kalil0321/ats-scrapers/commit/65ea087639287d3e2c96b9c2037becbf35a440b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59667570)</sub>

<!-- /greptile_comment -->